### PR TITLE
모든 상품 조회 기능 추가

### DIFF
--- a/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
@@ -33,9 +33,9 @@ public class BuyingService {
 	public BidResponse registerBuyingBid(Long id, String size, BidRequest bidRequest) {
 		ProductOption productOption = productService.findProductOptionByProductIdAndSize(id, size);
 
-		if (productOption.getBuyLowestPrice() > bidRequest.price()
-			|| productOption.getBuyLowestPrice() == 0) {
-			productOption.updateBuyLowestPrice(bidRequest.price());
+		if (productOption.getHighestPrice() > bidRequest.price()
+			|| productOption.getHighestPrice() == 0) {
+			productOption.updateBuyBidPrice(bidRequest.price());
 		}
 
 		User user = userService.findActiveUser(bidRequest.userId());

--- a/src/main/java/org/prgrms/cream/domain/product/controller/AdminController.java
+++ b/src/main/java/org/prgrms/cream/domain/product/controller/AdminController.java
@@ -1,12 +1,15 @@
 package org.prgrms.cream.domain.product.controller;
 
 import java.io.IOException;
+import java.util.List;
 import javax.validation.Valid;
 import org.prgrms.cream.domain.product.dto.ProductRequest;
+import org.prgrms.cream.domain.product.dto.ProductsResponse;
 import org.prgrms.cream.domain.product.service.ProductService;
 import org.prgrms.cream.global.response.ApiResponse;
 import org.prgrms.cream.global.service.S3Uploader;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -31,6 +34,11 @@ public class AdminController {
 	) {
 		this.s3Uploader = s3Uploader;
 		this.productService = productService;
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<ProductsResponse>>> getProducts() {
+		return ResponseEntity.ok(ApiResponse.of(productService.getProducts()));
 	}
 
 	@PostMapping

--- a/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
+++ b/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
@@ -1,0 +1,28 @@
+package org.prgrms.cream.domain.product.controller;
+
+import java.util.List;
+import org.prgrms.cream.domain.product.dto.ProductsResponse;
+import org.prgrms.cream.domain.product.service.ProductService;
+import org.prgrms.cream.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/products")
+public class ProductController {
+
+	private final ProductService productService;
+
+	public ProductController(
+		ProductService productService
+	) {
+		this.productService = productService;
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<ProductsResponse>>> getProducts() {
+		return ResponseEntity.ok(ApiResponse.of(productService.getProducts()));
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/product/domain/ProductOption.java
+++ b/src/main/java/org/prgrms/cream/domain/product/domain/ProductOption.java
@@ -29,10 +29,10 @@ public class ProductOption {
 	private String size;
 
 	@Column(nullable = false, columnDefinition = "default 0")
-	private int buyLowestPrice;
+	private int highestPrice;
 
 	@Column(nullable = false, columnDefinition = "default 0")
-	private int sellHighestPrice;
+	private int lowestPrice;
 
 	protected ProductOption() {
 	}
@@ -44,11 +44,11 @@ public class ProductOption {
 		this.size = size;
 	}
 
-	public void updateBuyLowestPrice(int price) {
-		this.buyLowestPrice = price;
+	public void updateBuyBidPrice(int price) {
+		this.highestPrice = price;
 	}
 
-	public void updateSellHighestPrice(int price) {
-		this.sellHighestPrice = price;
+	public void updateSellBidPrice(int price) {
+		this.lowestPrice = price;
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/product/dto/ProductsResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/product/dto/ProductsResponse.java
@@ -18,13 +18,13 @@ public class ProductsResponse {
 	public ProductsResponse() {
 	}
 
-	public ProductsResponse(Product product, int straightBuyPrice, int straightSellPrice) {
+	public ProductsResponse(Product product, int sellLowestPrice, int buyHighestPrice) {
 		this.id = product.getId();
 		this.brand = product.getBrand();
 		this.englishName = product.getEnglishName();
 		this.koreanName = product.getKoreanName();
-		this.straightBuyPrice = straightBuyPrice;
-		this.straightSellPrice = straightSellPrice;
+		this.straightBuyPrice = sellLowestPrice;
+		this.straightSellPrice = buyHighestPrice;
 		this.releaseDate = product.getReleaseDate();
 		this.image = product.getImage();
 	}

--- a/src/main/java/org/prgrms/cream/domain/product/dto/ProductsResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/product/dto/ProductsResponse.java
@@ -1,0 +1,31 @@
+package org.prgrms.cream.domain.product.dto;
+
+import lombok.Getter;
+import org.prgrms.cream.domain.product.domain.Product;
+
+@Getter
+public class ProductsResponse {
+
+	private Long id;
+	private String brand;
+	private String englishName;
+	private String koreanName;
+	private int straightBuyPrice;
+	private int straightSellPrice;
+	private String releaseDate;
+	private String image;
+
+	public ProductsResponse() {
+	}
+
+	public ProductsResponse(Product product, int straightBuyPrice, int straightSellPrice) {
+		this.id = product.getId();
+		this.brand = product.getBrand();
+		this.englishName = product.getEnglishName();
+		this.koreanName = product.getKoreanName();
+		this.straightBuyPrice = straightBuyPrice;
+		this.straightSellPrice = straightSellPrice;
+		this.releaseDate = product.getReleaseDate();
+		this.image = product.getImage();
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/product/repository/ProductOptionRepository.java
@@ -1,5 +1,6 @@
 package org.prgrms.cream.domain.product.repository;
 
+import java.util.Optional;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.prgrms.cream.domain.product.domain.ProductOption;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
 
 	boolean existsByProductAndSize(Product product, String size);
+
+	Optional<ProductOption> findFirstByProductAndBuyLowestPriceNotOrderByBuyLowestPrice(
+		Product product,
+		int zero
+	);
+
+	Optional<ProductOption> findFirstByProductOrderBySellHighestPriceAsc(Product product);
 }

--- a/src/main/java/org/prgrms/cream/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/product/repository/ProductOptionRepository.java
@@ -9,12 +9,12 @@ public interface ProductOptionRepository extends JpaRepository<ProductOption, Lo
 
 	boolean existsByProductAndSize(Product product, String size);
 
-	Optional<ProductOption> findFirstByProductAndBuyLowestPriceNotOrderByBuyLowestPrice(
+	Optional<ProductOption> findFirstByProductAndLowestPriceNotOrderByLowestPrice(
 		Product product,
 		int zero
 	);
 
-	Optional<ProductOption> findFirstByProductOrderBySellHighestPriceAsc(Product product);
+	Optional<ProductOption> findFirstByProductOrderByHighestPriceDesc(Product product);
 
 	Optional<ProductOption> findByProductAndSize(Product product, String size);
 }

--- a/src/main/java/org/prgrms/cream/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/product/repository/ProductRepository.java
@@ -1,10 +1,13 @@
 package org.prgrms.cream.domain.product.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-	Optional<Product> findByIdAndIsDeleted(Long id, boolean deleted);
+	List<Product> findAllByIsDeletedFalse();
+
+	Optional<Product> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
+++ b/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
@@ -68,7 +68,7 @@ public class ProductService {
 		}
 	}
 
-	private Product findActiveProduct(Long id) {
+	public Product findActiveProduct(Long id) {
 		return productRepository
 			.findByIdAndIsDeletedFalse(id)
 			.orElseThrow(() -> new NotFoundProductException(ErrorCode.NOT_FOUND_RESOURCE));

--- a/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
+++ b/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
@@ -82,26 +82,20 @@ public class ProductService {
 	}
 
 	private ProductsResponse toProductResponse(Product product) {
-		Optional<ProductOption> optBuyLowestPrice = productOptionRepository
-			.findFirstByProductAndBuyLowestPriceNotOrderByBuyLowestPrice(product, ZERO);
+		Optional<ProductOption> optLowestPrice = productOptionRepository
+			.findFirstByProductAndLowestPriceNotOrderByLowestPrice(product, ZERO);
 
-		Optional<ProductOption> optSellHighestPrice = productOptionRepository
-			.findFirstByProductOrderBySellHighestPriceAsc(product);
+		Optional<ProductOption> optHighestPrice = productOptionRepository
+			.findFirstByProductOrderByHighestPriceDesc(product);
 
-		int buyLowestPrice = NO_BID;
-		if (optBuyLowestPrice.isPresent()) {
-			buyLowestPrice = optBuyLowestPrice
-				.get()
-				.getBuyLowestPrice();
-		}
+		int lowestPrice = optLowestPrice.isEmpty() ? NO_BID : optLowestPrice
+			.get()
+			.getLowestPrice();
 
-		int sellHighestPrice = NO_BID;
-		if (optSellHighestPrice.isPresent()) {
-			sellHighestPrice = optSellHighestPrice
-				.get()
-				.getSellHighestPrice();
-		}
+		int highestPrice = optHighestPrice.isEmpty() ? NO_BID : optHighestPrice
+			.get()
+			.getHighestPrice();
 
-		return new ProductsResponse(product, buyLowestPrice, sellHighestPrice);
+		return new ProductsResponse(product, lowestPrice, highestPrice);
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
+++ b/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
@@ -1,7 +1,11 @@
 package org.prgrms.cream.domain.product.service;
 
+import java.util.List;
+import java.util.Optional;
 import org.prgrms.cream.domain.product.domain.Product;
+import org.prgrms.cream.domain.product.domain.ProductOption;
 import org.prgrms.cream.domain.product.dto.ProductRequest;
+import org.prgrms.cream.domain.product.dto.ProductsResponse;
 import org.prgrms.cream.domain.product.exception.NotFoundProductException;
 import org.prgrms.cream.domain.product.repository.ProductOptionRepository;
 import org.prgrms.cream.domain.product.repository.ProductRepository;
@@ -12,6 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ProductService {
 
+	private static final int NO_BID = 0;
+	private static final int ZERO = 0;
+
 	private final ProductRepository productRepository;
 	private final ProductOptionRepository productOptionRepository;
 
@@ -21,6 +28,15 @@ public class ProductService {
 	) {
 		this.productRepository = productRepository;
 		this.productOptionRepository = productOptionRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<ProductsResponse> getProducts() {
+		return productRepository
+			.findAllByIsDeletedFalse()
+			.stream()
+			.map(this::toProductResponse)
+			.toList();
 	}
 
 	@Transactional
@@ -54,7 +70,31 @@ public class ProductService {
 
 	private Product findActiveProduct(Long id) {
 		return productRepository
-			.findByIdAndIsDeleted(id, false)
+			.findByIdAndIsDeletedFalse(id)
 			.orElseThrow(() -> new NotFoundProductException(ErrorCode.NOT_FOUND_RESOURCE));
+	}
+
+	private ProductsResponse toProductResponse(Product product) {
+		Optional<ProductOption> optBuyLowestPrice = productOptionRepository
+			.findFirstByProductAndBuyLowestPriceNotOrderByBuyLowestPrice(product, ZERO);
+
+		Optional<ProductOption> optSellHighestPrice = productOptionRepository
+			.findFirstByProductOrderBySellHighestPriceAsc(product);
+
+		int buyLowestPrice = NO_BID;
+		if (optBuyLowestPrice.isPresent()) {
+			buyLowestPrice = optBuyLowestPrice
+				.get()
+				.getBuyLowestPrice();
+		}
+
+		int sellHighestPrice = NO_BID;
+		if (optSellHighestPrice.isPresent()) {
+			sellHighestPrice = optSellHighestPrice
+				.get()
+				.getSellHighestPrice();
+		}
+
+		return new ProductsResponse(product, buyLowestPrice, sellHighestPrice);
 	}
 }


### PR DESCRIPTION
- 조회 기능을 관리자, 사용자 공통으로 사용하기위해 두 컨트롤러에서 ProductService 의존성 주입
- [코드](https://github.com/prgrms-be-devcourse/BEDV1_CREAM/pull/15/files#r739105984) 해당 상품의 즉시 구매가(구매가 중 최저값), 즉시 판매가(판매가 중 최고값)를 가져오기 위한 로직을 구현하는 부분을 깔끔하게 리팩토링하고 싶은데 지금 방법이 최선이네요... 