### PR TITLE
즉시구매 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/cream/domain/deal/controller/BuyingController.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/controller/BuyingController.java
@@ -42,7 +42,7 @@ public class BuyingController {
 		@RequestParam String size,
 		@RequestBody BuyRequest buyRequest
 	) {
-		return ResponseEntity.ok(
-			ApiResponse.of(buyingService.straightBuyProduct(productId, size, buyRequest)));
+		return ResponseEntity.ok(ApiResponse.of(
+			buyingService.straightBuyProduct(productId, size, buyRequest)));
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/controller/BuyingController.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/controller/BuyingController.java
@@ -1,12 +1,16 @@
 package org.prgrms.cream.domain.deal.controller;
 
+import javax.validation.Valid;
 import org.prgrms.cream.domain.deal.dto.BidRequest;
 import org.prgrms.cream.domain.deal.dto.BidResponse;
+import org.prgrms.cream.domain.deal.dto.BuyRequest;
+import org.prgrms.cream.domain.deal.dto.DealResponse;
 import org.prgrms.cream.domain.deal.service.BuyingService;
 import org.prgrms.cream.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,13 +26,23 @@ public class BuyingController {
 		this.buyingService = buyingService;
 	}
 
-	@PostMapping("/{id}")
+	@PutMapping("/{id}")
 	public ResponseEntity<ApiResponse<BidResponse>> registerBuyingBid(
 		@PathVariable Long id,
 		@RequestParam String size,
-		@RequestBody BidRequest bidRequest
+		@Valid @RequestBody BidRequest bidRequest
 	) {
 		return ResponseEntity.ok(ApiResponse.of(
 			buyingService.registerBuyingBid(id, size, bidRequest)));
+	}
+
+	@PostMapping("/{productId}")
+	public ResponseEntity<ApiResponse<DealResponse>> straightBuyProduct(
+		@PathVariable Long productId,
+		@RequestParam String size,
+		@RequestBody BuyRequest buyRequest
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.of(buyingService.straightBuyProduct(productId, size, buyRequest)));
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/domain/Deal.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/domain/Deal.java
@@ -12,6 +12,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.prgrms.cream.domain.deal.dto.DealResponse;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.prgrms.cream.domain.user.domain.User;
 import org.prgrms.cream.global.domain.BaseEntity;
@@ -68,5 +69,14 @@ public class Deal extends BaseEntity {
 		this.product = product;
 		this.size = size;
 		this.price = price;
+	}
+
+	public DealResponse toResponse() {
+		return DealResponse.of(
+			id,
+			product.getEnglishName(),
+			size,
+			price
+		);
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/domain/Deal.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/domain/Deal.java
@@ -1,5 +1,7 @@
 package org.prgrms.cream.domain.deal.domain;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -76,7 +78,12 @@ public class Deal extends BaseEntity {
 			id,
 			product.getEnglishName(),
 			size,
-			price
+			price,
+			convertDateTime(this.getCreatedDate())
 		);
+	}
+
+	private String convertDateTime(LocalDateTime dateTime) {
+		return dateTime.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/domain/SellingBid.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/domain/SellingBid.java
@@ -11,6 +11,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.prgrms.cream.domain.deal.model.DealStatus;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.prgrms.cream.domain.user.domain.User;
 import org.prgrms.cream.global.domain.BaseEntity;
@@ -62,5 +63,9 @@ public class SellingBid extends BaseEntity {
 		this.size = size;
 		this.suggestPrice = suggestPrice;
 		this.deadline = deadline;
+	}
+
+	public void changeStatus(DealStatus dealStatus) {
+		this.status = dealStatus.getStatus();
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/BuyRequest.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/BuyRequest.java
@@ -1,0 +1,7 @@
+package org.prgrms.cream.domain.deal.dto;
+
+public record BuyRequest(
+	Long userId
+) {
+
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/DealResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/DealResponse.java
@@ -4,10 +4,17 @@ public record DealResponse(
 	Long dealId,
 	String productName,
 	String size,
-	Integer price
+	int price,
+	String createdDate
 ) {
 
-	public static DealResponse of(Long id, String productName, String size, Integer price) {
-		return new DealResponse(id, productName, size, price);
+	public static DealResponse of(
+		Long id,
+		String productName,
+		String size,
+		int price,
+		String createdDate
+	) {
+		return new DealResponse(id, productName, size, price, createdDate);
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/DealResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/DealResponse.java
@@ -1,0 +1,13 @@
+package org.prgrms.cream.domain.deal.dto;
+
+public record DealResponse(
+	Long dealId,
+	String productName,
+	String size,
+	Integer price
+) {
+
+	public static DealResponse of(Long id, String productName, String size, Integer price) {
+		return new DealResponse(id, productName, size, price);
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/exception/NotFoundBidException.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/exception/NotFoundBidException.java
@@ -1,0 +1,11 @@
+package org.prgrms.cream.domain.deal.exception;
+
+import org.prgrms.cream.global.error.ErrorCode;
+import org.prgrms.cream.global.error.exception.NotFoundException;
+
+public class NotFoundBidException extends NotFoundException {
+
+	public NotFoundBidException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/model/DealStatus.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/model/DealStatus.java
@@ -1,0 +1,19 @@
+package org.prgrms.cream.domain.deal.model;
+
+import lombok.Getter;
+
+@Getter
+public enum DealStatus {
+	BIDDING("입찰 중"),
+	EXPIRED("기한만료"),
+	BID_COMPLETED("입찰 완료"),
+	UNDER_INSPECTION("검수 중"),
+	SHIP_COMPLETED("배송완료"),
+	;
+
+	private final String status;
+
+	DealStatus(String status) {
+		this.status = status;
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/DealRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/DealRepository.java
@@ -1,0 +1,8 @@
+package org.prgrms.cream.domain.deal.repository;
+
+import org.prgrms.cream.domain.deal.domain.Deal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DealRepository extends JpaRepository<Deal, Long> {
+
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
@@ -1,13 +1,13 @@
 package org.prgrms.cream.domain.deal.repository;
 
-import java.util.Optional;
+import java.util.List;
 import org.prgrms.cream.domain.deal.domain.SellingBid;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SellingRepository extends JpaRepository<SellingBid, Long> {
 
-	Optional<SellingBid> findFirstByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
+	List<SellingBid> findFirst2ByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
 		Product product,
 		String size,
 		String status

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
@@ -1,0 +1,15 @@
+package org.prgrms.cream.domain.deal.repository;
+
+import java.util.Optional;
+import org.prgrms.cream.domain.deal.domain.SellingBid;
+import org.prgrms.cream.domain.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellingRepository extends JpaRepository<SellingBid, Long> {
+
+	Optional<SellingBid> findFirstByProductAndSizeAndStatusOrderBySuggestPriceDescCreatedDateAsc(
+		Product product,
+		String size,
+		String status
+	);
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SellingRepository extends JpaRepository<SellingBid, Long> {
 
-	Optional<SellingBid> findFirstByProductAndSizeAndStatusOrderBySuggestPriceDescCreatedDateAsc(
+	Optional<SellingBid> findFirstByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
 		Product product,
 		String size,
 		String status

--- a/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
@@ -2,9 +2,15 @@ package org.prgrms.cream.domain.deal.service;
 
 import java.time.format.DateTimeFormatter;
 import org.prgrms.cream.domain.deal.domain.BuyingBid;
+import org.prgrms.cream.domain.deal.domain.Deal;
+import org.prgrms.cream.domain.deal.domain.SellingBid;
 import org.prgrms.cream.domain.deal.dto.BidRequest;
 import org.prgrms.cream.domain.deal.dto.BidResponse;
+import org.prgrms.cream.domain.deal.dto.BuyRequest;
+import org.prgrms.cream.domain.deal.dto.DealResponse;
+import org.prgrms.cream.domain.deal.model.DealStatus;
 import org.prgrms.cream.domain.deal.repository.BuyingRepository;
+import org.prgrms.cream.domain.product.domain.Product;
 import org.prgrms.cream.domain.product.domain.ProductOption;
 import org.prgrms.cream.domain.product.service.ProductService;
 import org.prgrms.cream.domain.user.domain.User;
@@ -18,15 +24,21 @@ public class BuyingService {
 	private final BuyingRepository buyingRepository;
 	private final ProductService productService;
 	private final UserService userService;
+	private final SellingService sellingService;
+	private final DealService dealService;
 
 	public BuyingService(
 		BuyingRepository buyingRepository,
 		ProductService productService,
-		UserService userService
+		UserService userService,
+		SellingService sellingService,
+		DealService dealService
 	) {
 		this.buyingRepository = buyingRepository;
 		this.productService = productService;
 		this.userService = userService;
+		this.sellingService = sellingService;
+		this.dealService = dealService;
 	}
 
 	@Transactional
@@ -54,5 +66,35 @@ public class BuyingService {
 			.plusDays(buyingBid.getDeadline())
 			.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
 		return new BidResponse(buyingBid.getSuggestPrice(), buyingBid.getDeadline(), expiredDate);
+	}
+
+	@Transactional
+	public DealResponse straightBuyProduct(Long productId, String size, BuyRequest buyRequest) {
+		Product product = productService.findActiveProduct(productId);
+		SellingBid topSellingBid = sellingService
+			.findSellingBidOfHighestPrice(product, size, DealStatus.BIDDING);
+		topSellingBid.changeStatus(DealStatus.BID_COMPLETED);
+
+		SellingBid secondSellingBid = sellingService
+			.findSellingBidOfHighestPrice(product, size, DealStatus.BIDDING);
+		productService
+			.findProductOptionByProductIdAndSize(
+				productId,
+				size
+			)
+			.updateBuyBidPrice(secondSellingBid.getSuggestPrice());
+
+		return dealService
+			.makeDeal(
+				Deal
+					.builder()
+					.buyer(userService.findActiveUser(buyRequest.userId()))
+					.seller(topSellingBid.getUser())
+					.product(topSellingBid.getProduct())
+					.size(size)
+					.price(topSellingBid.getSuggestPrice())
+					.build()
+			)
+			.toResponse();
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
@@ -85,7 +85,7 @@ public class BuyingService {
 			.updateSellBidPrice(secondSellingBid.getSuggestPrice());
 
 		return dealService
-			.makeDeal(
+			.createDeal(
 				Deal
 					.builder()
 					.buyer(userService.findActiveUser(buyRequest.userId()))

--- a/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/BuyingService.java
@@ -72,17 +72,17 @@ public class BuyingService {
 	public DealResponse straightBuyProduct(Long productId, String size, BuyRequest buyRequest) {
 		Product product = productService.findActiveProduct(productId);
 		SellingBid topSellingBid = sellingService
-			.findSellingBidOfHighestPrice(product, size, DealStatus.BIDDING);
+			.findSellingBidOfLowestPrice(product, size, DealStatus.BIDDING);
 		topSellingBid.changeStatus(DealStatus.BID_COMPLETED);
 
 		SellingBid secondSellingBid = sellingService
-			.findSellingBidOfHighestPrice(product, size, DealStatus.BIDDING);
+			.findSellingBidOfLowestPrice(product, size, DealStatus.BIDDING);
 		productService
 			.findProductOptionByProductIdAndSize(
 				productId,
 				size
 			)
-			.updateBuyBidPrice(secondSellingBid.getSuggestPrice());
+			.updateSellBidPrice(secondSellingBid.getSuggestPrice());
 
 		return dealService
 			.makeDeal(

--- a/src/main/java/org/prgrms/cream/domain/deal/service/DealService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/DealService.java
@@ -1,0 +1,19 @@
+package org.prgrms.cream.domain.deal.service;
+
+import org.prgrms.cream.domain.deal.domain.Deal;
+import org.prgrms.cream.domain.deal.repository.DealRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DealService {
+
+	private final DealRepository dealRepository;
+
+	public DealService(DealRepository dealRepository) {
+		this.dealRepository = dealRepository;
+	}
+
+	public Deal makeDeal(Deal deal) {
+		return dealRepository.save(deal);
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/service/DealService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/DealService.java
@@ -13,7 +13,7 @@ public class DealService {
 		this.dealRepository = dealRepository;
 	}
 
-	public Deal makeDeal(Deal deal) {
+	public Deal createDeal(Deal deal) {
 		return dealRepository.save(deal);
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
@@ -1,5 +1,6 @@
 package org.prgrms.cream.domain.deal.service;
 
+import java.util.List;
 import org.prgrms.cream.domain.deal.domain.SellingBid;
 import org.prgrms.cream.domain.deal.exception.NotFoundBidException;
 import org.prgrms.cream.domain.deal.model.DealStatus;
@@ -19,17 +20,22 @@ public class SellingService {
 	}
 
 	@Transactional(readOnly = true)
-	public SellingBid findSellingBidOfLowestPrice(
+	public List<SellingBid> findSellingBidsOfLowestPrice(
 		Product product,
 		String size,
 		DealStatus dealStatus
 	) {
-		return sellingRepository
-			.findFirstByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
+		List<SellingBid> sellingBids = sellingRepository
+			.findFirst2ByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
 				product,
 				size,
 				dealStatus.getStatus()
-			)
-			.orElseThrow(() -> new NotFoundBidException(ErrorCode.NOT_FOUND_RESOURCE));
+			);
+
+		if (sellingBids.isEmpty()) {
+			throw new NotFoundBidException(ErrorCode.NOT_FOUND_RESOURCE);
+		}
+
+		return sellingBids;
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
@@ -19,13 +19,13 @@ public class SellingService {
 	}
 
 	@Transactional(readOnly = true)
-	public SellingBid findSellingBidOfHighestPrice(
+	public SellingBid findSellingBidOfLowestPrice(
 		Product product,
 		String size,
 		DealStatus dealStatus
 	) {
 		return sellingRepository
-			.findFirstByProductAndSizeAndStatusOrderBySuggestPriceDescCreatedDateAsc(
+			.findFirstByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
 				product,
 				size,
 				dealStatus.getStatus()

--- a/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
@@ -1,0 +1,35 @@
+package org.prgrms.cream.domain.deal.service;
+
+import org.prgrms.cream.domain.deal.domain.SellingBid;
+import org.prgrms.cream.domain.deal.exception.NotFoundBidException;
+import org.prgrms.cream.domain.deal.model.DealStatus;
+import org.prgrms.cream.domain.deal.repository.SellingRepository;
+import org.prgrms.cream.domain.product.domain.Product;
+import org.prgrms.cream.global.error.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SellingService {
+
+	private final SellingRepository sellingRepository;
+
+	public SellingService(SellingRepository sellingRepository) {
+		this.sellingRepository = sellingRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public SellingBid findSellingBidOfHighestPrice(
+		Product product,
+		String size,
+		DealStatus dealStatus
+	) {
+		return sellingRepository
+			.findFirstByProductAndSizeAndStatusOrderBySuggestPriceDescCreatedDateAsc(
+				product,
+				size,
+				dealStatus.getStatus()
+			)
+			.orElseThrow(() -> new NotFoundBidException(ErrorCode.NOT_FOUND_RESOURCE));
+	}
+}

--- a/src/main/java/org/prgrms/cream/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgrms/cream/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.prgrms.cream.global.error;
 
 import lombok.extern.slf4j.Slf4j;
+import org.prgrms.cream.domain.deal.exception.NotFoundBidException;
 import org.prgrms.cream.domain.product.exception.NotFoundProductException;
 import org.prgrms.cream.domain.user.exception.DuplicateUserException;
 import org.prgrms.cream.domain.user.exception.InvalidArgumentException;
@@ -33,7 +34,13 @@ public class GlobalExceptionHandler {
 		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
 	}
 
-	@ExceptionHandler({NotFoundProductException.class, NotFoundUserException.class})
+	@ExceptionHandler(
+		{
+			NotFoundProductException.class,
+			NotFoundUserException.class,
+			NotFoundBidException.class
+		}
+	)
 	public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException exception) {
 		log.error("handleNotFoundException", exception);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND_RESOURCE);


### PR DESCRIPTION
### 설명
- 즉시구매 엔드포인트를 PostMapping, 구매 입찰 엔드포인트를 PutMapping으로 변경
- Deal 엔티티에서 Response 객체로 변환
- 요청, 응답 DTO 설계
- 거래 상태를 enum 클래스에서 관리
- 즉시 구매 예외 처리(판매 입찰 내역이 존재하지 않을 때)

### 질문
판매 입찰 내역 중 최고가, 등록한 기준으로 첫 판매 입찰 내역을 찾아서 거래 체결을 진행하고, 그다음 같은 방식으로 다시 판매 입찰 내역을 찾아 해당 입찰 금액으로 최고가를 갱신합니다. 이러한 과정에서 두 번의 입찰 내역 조회 쿼리를 날리게 되는데, 한 번으로 줄일 수 있는 방법이 있을 것 같다는 생각을 했습니다. 더 효율적인 로직을 구현할 수 있을까요?