### PR TITLE
특정 상품 상세 조회 기능 추가 

### DIFF
--- a/src/main/java/org/prgrms/cream/domain/deal/dto/BidDetail.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/BidDetail.java
@@ -1,0 +1,10 @@
+package org.prgrms.cream.domain.deal.dto;
+
+public interface BidDetail {
+
+	String getSize();
+
+	Integer getPrice();
+
+	Integer getQuantity();
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/BuyingBidPriceResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/BuyingBidPriceResponse.java
@@ -1,0 +1,17 @@
+package org.prgrms.cream.domain.deal.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BuyingBidPriceResponse {
+
+	private String size;
+	private int buyingPrice;
+	private int quantity;
+
+	public BuyingBidPriceResponse(String size, int buyingPrice, int quantity) {
+		this.size = size;
+		this.buyingPrice = buyingPrice;
+		this.quantity = quantity;
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/DealPriceResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/DealPriceResponse.java
@@ -1,0 +1,17 @@
+package org.prgrms.cream.domain.deal.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DealPriceResponse {
+
+	private String size;
+	private int dealPrice;
+	private String dealDate;
+
+	public DealPriceResponse(String size, int dealPrice, String dealDate) {
+		this.size = size;
+		this.dealPrice = dealPrice;
+		this.dealDate = dealDate;
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/SellingBidPriceResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/SellingBidPriceResponse.java
@@ -1,0 +1,17 @@
+package org.prgrms.cream.domain.deal.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SellingBidPriceResponse {
+
+	private String size;
+	private int sellingPrice;
+	private int quantity;
+
+	public SellingBidPriceResponse(String size, int sellingPrice, int quantity) {
+		this.size = size;
+		this.sellingPrice = sellingPrice;
+		this.quantity = quantity;
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
@@ -1,8 +1,26 @@
 package org.prgrms.cream.domain.deal.repository;
 
+import java.util.List;
 import org.prgrms.cream.domain.deal.domain.BuyingBid;
+import org.prgrms.cream.domain.deal.dto.BidDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BuyingRepository extends JpaRepository<BuyingBid, Long> {
 
+	@Query(value =
+		"SELECT b.size, b.suggest_price as price, COUNT(*) as quantity "
+			+ "FROM buying_bid b "
+			+ "WHERE b.product_id = ?1 "
+			+ "GROUP BY b.product_id, b.size, b.suggest_price "
+			+ "ORDER BY b.suggest_price DESC", nativeQuery = true)
+	List<BidDetail> findAllByProductGroupBy(Long productId);
+
+	@Query(value =
+		"SELECT b.size, b.suggest_price as price, COUNT(*) as quantity "
+			+ "FROM buying_bid b "
+			+ "WHERE b.product_id = ?1 AND b.size = ?2 "
+			+ "GROUP BY b.product_id, b.size, b.suggest_price "
+			+ "ORDER BY b.suggest_price DESC", nativeQuery = true)
+	List<BidDetail> findAllByProductAndSizeGroupBy(Long productId, String size);
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
@@ -8,19 +8,25 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface BuyingRepository extends JpaRepository<BuyingBid, Long> {
 
-	@Query(value =
-		"SELECT b.size, b.suggest_price as price, COUNT(*) as quantity "
-			+ "FROM buying_bid b "
-			+ "WHERE b.product_id = ?1 "
-			+ "GROUP BY b.product_id, b.size, b.suggest_price "
-			+ "ORDER BY b.suggest_price DESC", nativeQuery = true)
+	@Query(
+		value =
+			"SELECT b.size, b.suggest_price as price, COUNT(*) as quantity "
+				+ "FROM buying_bid b "
+				+ "WHERE b.product_id = ?1 "
+				+ "GROUP BY b.product_id, b.size, b.suggest_price "
+				+ "ORDER BY b.suggest_price DESC",
+		nativeQuery = true
+	)
 	List<BidDetail> findAllByProductGroupBy(Long productId);
 
-	@Query(value =
-		"SELECT b.size, b.suggest_price as price, COUNT(*) as quantity "
-			+ "FROM buying_bid b "
-			+ "WHERE b.product_id = ?1 AND b.size = ?2 "
-			+ "GROUP BY b.product_id, b.size, b.suggest_price "
-			+ "ORDER BY b.suggest_price DESC", nativeQuery = true)
+	@Query(
+		value =
+			"SELECT b.size, b.suggest_price as price, COUNT(*) as quantity "
+				+ "FROM buying_bid b "
+				+ "WHERE b.product_id = ?1 AND b.size = ?2 "
+				+ "GROUP BY b.product_id, b.size, b.suggest_price "
+				+ "ORDER BY b.suggest_price DESC",
+		nativeQuery = true
+	)
 	List<BidDetail> findAllByProductAndSizeGroupBy(Long productId, String size);
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/DealRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/DealRepository.java
@@ -1,0 +1,18 @@
+package org.prgrms.cream.domain.deal.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.prgrms.cream.domain.deal.domain.Deal;
+import org.prgrms.cream.domain.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DealRepository extends JpaRepository<Deal, Long> {
+
+	Optional<Deal> findFirstByProductOrderByCreatedDateDesc(Product product);
+
+	Optional<Deal> findFirstByProductAndSizeOrderByCreatedDateDesc(Product product, String size);
+
+	List<Deal> findAllByProductOrderByCreatedDateDesc(Product product);
+
+	List<Deal> findAllByProductAndSizeOrderByCreatedDateDesc(Product product, String size);
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
@@ -8,19 +8,25 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface SellingRepository extends JpaRepository<SellingBid, Long> {
 
-	@Query(value =
-		"SELECT s.size, s.suggest_price as price, COUNT(*) as quantity "
-			+ "FROM selling_bid s "
-			+ "WHERE s.product_id = ?1 "
-			+ "GROUP BY s.product_id, s.size, s.suggest_price "
-			+ "ORDER BY s.suggest_price", nativeQuery = true)
+	@Query(
+		value =
+			"SELECT s.size, s.suggest_price as price, COUNT(*) as quantity "
+				+ "FROM selling_bid s "
+				+ "WHERE s.product_id = ?1 "
+				+ "GROUP BY s.product_id, s.size, s.suggest_price "
+				+ "ORDER BY s.suggest_price",
+		nativeQuery = true
+	)
 	List<BidDetail> findAllByProductGroupBy(Long productId);
 
-	@Query(value =
-		"SELECT s.size, s.suggest_price as price, COUNT(*) as quantity "
-			+ "FROM selling_bid s "
-			+ "WHERE s.product_id = ?1 AND s.size = ?2 "
-			+ "GROUP BY s.product_id, s.size, s.suggest_price "
-			+ "ORDER BY s.suggest_price", nativeQuery = true)
+	@Query(
+		value =
+			"SELECT s.size, s.suggest_price as price, COUNT(*) as quantity "
+				+ "FROM selling_bid s "
+				+ "WHERE s.product_id = ?1 AND s.size = ?2 "
+				+ "GROUP BY s.product_id, s.size, s.suggest_price "
+				+ "ORDER BY s.suggest_price",
+		nativeQuery = true
+	)
 	List<BidDetail> findAllByProductAndSizeGroupBy(Long productId, String size);
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
@@ -1,0 +1,26 @@
+package org.prgrms.cream.domain.deal.repository;
+
+import java.util.List;
+import org.prgrms.cream.domain.deal.domain.SellingBid;
+import org.prgrms.cream.domain.deal.dto.BidDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface SellingRepository extends JpaRepository<SellingBid, Long> {
+
+	@Query(value =
+		"SELECT s.size, s.suggest_price as price, COUNT(*) as quantity "
+			+ "FROM selling_bid s "
+			+ "WHERE s.product_id = ?1 "
+			+ "GROUP BY s.product_id, s.size, s.suggest_price "
+			+ "ORDER BY s.suggest_price", nativeQuery = true)
+	List<BidDetail> findAllByProductGroupBy(Long productId);
+
+	@Query(value =
+		"SELECT s.size, s.suggest_price as price, COUNT(*) as quantity "
+			+ "FROM selling_bid s "
+			+ "WHERE s.product_id = ?1 AND s.size = ?2 "
+			+ "GROUP BY s.product_id, s.size, s.suggest_price "
+			+ "ORDER BY s.suggest_price", nativeQuery = true)
+	List<BidDetail> findAllByProductAndSizeGroupBy(Long productId, String size);
+}

--- a/src/main/java/org/prgrms/cream/domain/product/controller/AdminController.java
+++ b/src/main/java/org/prgrms/cream/domain/product/controller/AdminController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import javax.validation.Valid;
 import org.prgrms.cream.domain.product.dto.ProductRequest;
+import org.prgrms.cream.domain.product.dto.ProductResponse;
 import org.prgrms.cream.domain.product.dto.ProductsResponse;
 import org.prgrms.cream.domain.product.service.ProductService;
 import org.prgrms.cream.global.response.ApiResponse;
@@ -39,6 +40,11 @@ public class AdminController {
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<ProductsResponse>>> getProducts() {
 		return ResponseEntity.ok(ApiResponse.of(productService.getProducts()));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse<ProductResponse>> getProduct(@PathVariable Long id) {
+		return ResponseEntity.ok(ApiResponse.of(productService.getProduct(id)));
 	}
 
 	@PostMapping

--- a/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
+++ b/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
@@ -1,11 +1,13 @@
 package org.prgrms.cream.domain.product.controller;
 
 import java.util.List;
+import org.prgrms.cream.domain.product.dto.ProductResponse;
 import org.prgrms.cream.domain.product.dto.ProductsResponse;
 import org.prgrms.cream.domain.product.service.ProductService;
 import org.prgrms.cream.global.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,5 +26,10 @@ public class ProductController {
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<ProductsResponse>>> getProducts() {
 		return ResponseEntity.ok(ApiResponse.of(productService.getProducts()));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse<ProductResponse>> getProduct(@PathVariable Long id) {
+		return ResponseEntity.ok(ApiResponse.of(productService.getProduct(id)));
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
+++ b/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
@@ -46,6 +46,7 @@ public class ProductController {
 				optSize
 					.map(size -> productService.getProductDetailByOption(id, size))
 					.orElse(productService.getProductDetail(id))
-			));
+			)
+		);
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
+++ b/src/main/java/org/prgrms/cream/domain/product/controller/ProductController.java
@@ -1,6 +1,8 @@
 package org.prgrms.cream.domain.product.controller;
 
 import java.util.List;
+import java.util.Optional;
+import org.prgrms.cream.domain.product.dto.DetailResponse;
 import org.prgrms.cream.domain.product.dto.ProductResponse;
 import org.prgrms.cream.domain.product.dto.ProductsResponse;
 import org.prgrms.cream.domain.product.service.ProductService;
@@ -9,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,5 +34,18 @@ public class ProductController {
 	@GetMapping("/{id}")
 	public ResponseEntity<ApiResponse<ProductResponse>> getProduct(@PathVariable Long id) {
 		return ResponseEntity.ok(ApiResponse.of(productService.getProduct(id)));
+	}
+
+	@GetMapping("/{id}/details")
+	public ResponseEntity<ApiResponse<DetailResponse>> getProductDetail(
+		@PathVariable Long id,
+		@RequestParam Optional<String> optSize
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.of(
+				optSize
+					.map(size -> productService.getProductDetailByOption(id, size))
+					.orElse(productService.getProductDetail(id))
+			));
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/product/domain/ProductOption.java
+++ b/src/main/java/org/prgrms/cream/domain/product/domain/ProductOption.java
@@ -22,7 +22,7 @@ public class ProductOption {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "product_id", referencedColumnName = "id")
+	@JoinColumn(name = "product_id")
 	private Product product;
 
 	@Column(nullable = false)

--- a/src/main/java/org/prgrms/cream/domain/product/dto/DetailResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/product/dto/DetailResponse.java
@@ -1,0 +1,32 @@
+package org.prgrms.cream.domain.product.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import org.prgrms.cream.domain.deal.dto.BuyingBidPriceResponse;
+import org.prgrms.cream.domain.deal.dto.DealPriceResponse;
+import org.prgrms.cream.domain.deal.dto.SellingBidPriceResponse;
+
+@Getter
+public class DetailResponse {
+
+	private int recentDealPrice;
+	private List<DealPriceResponse> dealPriceResponses = new ArrayList<>();
+	private List<BuyingBidPriceResponse> buyingBidPriceResponses = new ArrayList<>();
+	private List<SellingBidPriceResponse> sellingBidPriceResponses = new ArrayList<>();
+
+	private DetailResponse() {
+	}
+
+	public DetailResponse(
+		int recentDealPrice,
+		List<DealPriceResponse> dealPriceResponses,
+		List<BuyingBidPriceResponse> buyingBidPriceResponses,
+		List<SellingBidPriceResponse> sellingBidPriceResponses
+	) {
+		this.recentDealPrice = recentDealPrice;
+		this.dealPriceResponses = dealPriceResponses;
+		this.buyingBidPriceResponses = buyingBidPriceResponses;
+		this.sellingBidPriceResponses = sellingBidPriceResponses;
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/product/dto/OptionResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/product/dto/OptionResponse.java
@@ -1,0 +1,15 @@
+package org.prgrms.cream.domain.product.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OptionResponse {
+
+	private String size;
+	private int straightBuyPrice;
+
+	public OptionResponse(String size, int straightBuyPrice) {
+		this.size = size;
+		this.straightBuyPrice = straightBuyPrice;
+	}
+}

--- a/src/main/java/org/prgrms/cream/domain/product/dto/OptionResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/product/dto/OptionResponse.java
@@ -7,9 +7,11 @@ public class OptionResponse {
 
 	private String size;
 	private int straightBuyPrice;
+	private int straightSellPrice;
 
-	public OptionResponse(String size, int straightBuyPrice) {
+	public OptionResponse(String size, int straightBuyPrice, int straightSellPrice) {
 		this.size = size;
 		this.straightBuyPrice = straightBuyPrice;
+		this.straightSellPrice = straightSellPrice;
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/product/dto/ProductResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/product/dto/ProductResponse.java
@@ -16,7 +16,6 @@ public class ProductResponse {
 	private String color;
 	private int releasePrice;
 	private String image;
-
 	private List<OptionResponse> options;
 
 	private ProductResponse() {

--- a/src/main/java/org/prgrms/cream/domain/product/dto/ProductResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/product/dto/ProductResponse.java
@@ -1,31 +1,40 @@
 package org.prgrms.cream.domain.product.dto;
 
+import java.util.List;
 import lombok.Getter;
 import org.prgrms.cream.domain.product.domain.Product;
 
 @Getter
-public class ProductsResponse {
+public class ProductResponse {
 
 	private Long id;
 	private String brand;
 	private String englishName;
 	private String koreanName;
-	private int straightBuyPrice;
-	private int straightSellPrice;
+	private String modelNumber;
 	private String releaseDate;
+	private String color;
+	private int releasePrice;
 	private String image;
 
-	private ProductsResponse() {
+	private List<OptionResponse> options;
+
+	private ProductResponse() {
 	}
 
-	public ProductsResponse(Product product, int sellLowestPrice, int buyHighestPrice) {
+	public ProductResponse(
+		Product product,
+		List<OptionResponse> options
+	) {
 		this.id = product.getId();
 		this.brand = product.getBrand();
 		this.englishName = product.getEnglishName();
 		this.koreanName = product.getKoreanName();
-		this.straightBuyPrice = sellLowestPrice;
-		this.straightSellPrice = buyHighestPrice;
+		this.modelNumber = product.getModelNumber();
 		this.releaseDate = product.getReleaseDate();
+		this.color = product.getColor();
+		this.releasePrice = product.getReleasePrice();
 		this.image = product.getImage();
+		this.options = options;
 	}
 }

--- a/src/main/java/org/prgrms/cream/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/product/repository/ProductOptionRepository.java
@@ -1,5 +1,6 @@
 package org.prgrms.cream.domain.product.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.prgrms.cream.domain.product.domain.ProductOption;
@@ -17,4 +18,6 @@ public interface ProductOptionRepository extends JpaRepository<ProductOption, Lo
 	Optional<ProductOption> findFirstByProductOrderByHighestPriceDesc(Product product);
 
 	Optional<ProductOption> findByProductAndSize(Product product, String size);
+
+	List<ProductOption> findByProduct(Product product);
 }

--- a/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
+++ b/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
@@ -85,7 +85,7 @@ public class ProductService {
 		Product product = findActiveProduct(id);
 
 		Optional<Deal> optDeal = dealRepository.findFirstByProductOrderByCreatedDateDesc(product);
-		int recentDealPrice = optDeal.isEmpty() ? 0 : optDeal
+		int recentDealPrice = optDeal.isEmpty() ? NO_DEAL : optDeal
 			.get()
 			.getPrice();
 

--- a/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
+++ b/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductService {
 
 	private static final int NO_BID = 0;
+	private static final int NO_DEAL = 0;
 	private static final int ZERO = 0;
 
 	private final ProductRepository productRepository;
@@ -72,7 +73,8 @@ public class ProductService {
 				.stream()
 				.map(productOption -> new OptionResponse(
 					productOption.getSize(),
-					productOption.getLowestPrice()
+					productOption.getLowestPrice(),
+					productOption.getHighestPrice()
 				))
 				.toList()
 		);
@@ -100,7 +102,7 @@ public class ProductService {
 
 		Optional<Deal> optDeal = dealRepository.findFirstByProductAndSizeOrderByCreatedDateDesc(
 			product, size);
-		int recentDealPrice = optDeal.isEmpty() ? 0 : optDeal
+		int recentDealPrice = optDeal.isEmpty() ? NO_DEAL : optDeal
 			.get()
 			.getPrice();
 

--- a/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
+++ b/src/main/java/org/prgrms/cream/domain/product/service/ProductService.java
@@ -1,9 +1,19 @@
 package org.prgrms.cream.domain.product.service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import org.prgrms.cream.domain.deal.domain.Deal;
+import org.prgrms.cream.domain.deal.dto.BidDetail;
+import org.prgrms.cream.domain.deal.dto.BuyingBidPriceResponse;
+import org.prgrms.cream.domain.deal.dto.DealPriceResponse;
+import org.prgrms.cream.domain.deal.dto.SellingBidPriceResponse;
+import org.prgrms.cream.domain.deal.repository.BuyingRepository;
+import org.prgrms.cream.domain.deal.repository.DealRepository;
+import org.prgrms.cream.domain.deal.repository.SellingRepository;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.prgrms.cream.domain.product.domain.ProductOption;
+import org.prgrms.cream.domain.product.dto.DetailResponse;
 import org.prgrms.cream.domain.product.dto.OptionResponse;
 import org.prgrms.cream.domain.product.dto.ProductRequest;
 import org.prgrms.cream.domain.product.dto.ProductResponse;
@@ -24,13 +34,22 @@ public class ProductService {
 
 	private final ProductRepository productRepository;
 	private final ProductOptionRepository productOptionRepository;
+	private final DealRepository dealRepository;
+	private final BuyingRepository buyingRepository;
+	private final SellingRepository sellingRepository;
 
 	public ProductService(
 		ProductRepository productRepository,
-		ProductOptionRepository productOptionRepository
+		ProductOptionRepository productOptionRepository,
+		DealRepository dealRepository,
+		BuyingRepository buyingRepository,
+		SellingRepository sellingRepository
 	) {
 		this.productRepository = productRepository;
 		this.productOptionRepository = productOptionRepository;
+		this.dealRepository = dealRepository;
+		this.buyingRepository = buyingRepository;
+		this.sellingRepository = sellingRepository;
 	}
 
 	@Transactional(readOnly = true)
@@ -57,6 +76,42 @@ public class ProductService {
 				))
 				.toList()
 		);
+	}
+
+	@Transactional(readOnly = true)
+	public DetailResponse getProductDetail(Long id) {
+		Product product = findActiveProduct(id);
+
+		Optional<Deal> optDeal = dealRepository.findFirstByProductOrderByCreatedDateDesc(product);
+		int recentDealPrice = optDeal.isEmpty() ? 0 : optDeal
+			.get()
+			.getPrice();
+
+		List<Deal> dealPrices = dealRepository.findAllByProductOrderByCreatedDateDesc(product);
+		List<BidDetail> buyingBids = buyingRepository.findAllByProductGroupBy(product.getId());
+		List<BidDetail> sellingBids = sellingRepository.findAllByProductGroupBy(product.getId());
+
+		return toDetailResponse(recentDealPrice, dealPrices, buyingBids, sellingBids);
+	}
+
+	@Transactional(readOnly = true)
+	public DetailResponse getProductDetailByOption(Long id, String size) {
+		Product product = findActiveProduct(id);
+
+		Optional<Deal> optDeal = dealRepository.findFirstByProductAndSizeOrderByCreatedDateDesc(
+			product, size);
+		int recentDealPrice = optDeal.isEmpty() ? 0 : optDeal
+			.get()
+			.getPrice();
+
+		List<Deal> dealPrices = dealRepository.findAllByProductAndSizeOrderByCreatedDateDesc(
+			product, size);
+		List<BidDetail> buyingBids = buyingRepository.findAllByProductAndSizeGroupBy(
+			product.getId(), size);
+		List<BidDetail> sellingBids = sellingRepository.findAllByProductAndSizeGroupBy(
+			product.getId(), size);
+
+		return toDetailResponse(recentDealPrice, dealPrices, buyingBids, sellingBids);
 	}
 
 	@Transactional
@@ -112,6 +167,46 @@ public class ProductService {
 
 		return new ProductsResponse(product, lowestPrice, highestPrice);
 	}
+
+	private DetailResponse toDetailResponse(
+		int recentDealPrice,
+		List<Deal> dealPrices,
+		List<BidDetail> buyingBids,
+		List<BidDetail> sellingBids
+	) {
+
+		List<DealPriceResponse> dealPriceRes = dealPrices
+			.stream()
+			.map(deal -> new DealPriceResponse(
+				deal.getSize(),
+				deal.getPrice(),
+				deal
+					.getCreatedDate()
+					.format(DateTimeFormatter.ofPattern("yy/MM/dd"))
+			))
+			.toList();
+
+		List<BuyingBidPriceResponse> buyingBidRes = buyingBids
+			.stream()
+			.map(buyingBid -> new BuyingBidPriceResponse(
+				buyingBid.getSize(),
+				buyingBid.getPrice(),
+				buyingBid.getQuantity()
+			))
+			.toList();
+
+		List<SellingBidPriceResponse> sellingBidRes = sellingBids
+			.stream()
+			.map(sellingBid -> new SellingBidPriceResponse(
+				sellingBid.getSize(),
+				sellingBid.getPrice(),
+				sellingBid.getQuantity()
+			))
+			.toList();
+
+		return new DetailResponse(recentDealPrice, dealPriceRes, buyingBidRes, sellingBidRes);
+	}
+
 
 	private void modifyOption(Product product, String size) {
 		boolean isExist = productOptionRepository.existsByProductAndSize(product, size);


### PR DESCRIPTION
#### 특정상품 상세 정보 조회 API 추가
- 상품의 기본정보와 여러 사이즈마다 즉시 구매가를 조회할 수 있도록 구현
- 즉시 구매가 : 판매입찰에 등록된 판매 희망가 중 최저값

#### 선택한 사이즈에 따른 상세 정보 조회 API 추가
- 특정 상품의 최근거래가, 체결거래, 판매입찰, 구매입찰 내역 조회 기능 구현
- size 옵션이 있다면 해당 사이즈의 내역만 조회