### PR TITLE
판매입찰 삭제 기능 추가

### DIFF
--- a/src/main/java/org/prgrms/cream/domain/deal/model/DealStatus.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/model/DealStatus.java
@@ -9,6 +9,7 @@ public enum DealStatus {
 	BID_COMPLETED("입찰 완료"),
 	UNDER_INSPECTION("검수 중"),
 	SHIP_COMPLETED("배송완료"),
+	BID_CANCELLED("입찰 취소"),
 	;
 
 	private final String status;

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/SellingRepository.java
@@ -2,26 +2,32 @@ package org.prgrms.cream.domain.deal.repository;
 
 import java.util.List;
 import java.util.Optional;
-import org.prgrms.cream.domain.deal.dto.BidDetail;
 import org.prgrms.cream.domain.deal.domain.SellingBid;
+import org.prgrms.cream.domain.deal.dto.BidDetail;
 import org.prgrms.cream.domain.product.domain.Product;
 import org.prgrms.cream.domain.user.domain.User;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SellingRepository extends JpaRepository<SellingBid, Long> {
 
 	boolean existsByUserAndProductAndSize(User user, Product product, String size);
-  
-  Optional<SellingBid> findByUserAndProductAndSize(User user, Product product, String size);
+
+	Optional<SellingBid> findByUserAndProductAndSize(User user, Product product, String size);
 
 	List<SellingBid> findFirst2ByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
 		Product product,
 		String size,
 		String status
 	);
-  
-  @Query(
+
+	Optional<SellingBid> findTopByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
+		Product product,
+		String size,
+		String status
+	);
+
+	@Query(
 		value =
 			"SELECT s.size, s.suggest_price as price, COUNT(*) as quantity "
 				+ "FROM selling_bid s "
@@ -42,4 +48,6 @@ public interface SellingRepository extends JpaRepository<SellingBid, Long> {
 		nativeQuery = true
 	)
 	List<BidDetail> findAllByProductAndSizeGroupBy(Long productId, String size);
+
+	Optional<SellingBid> findByIdAndUserAndStatus(Long bidId, User user, String status);
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/service/SellingService.java
@@ -1,6 +1,7 @@
 package org.prgrms.cream.domain.deal.service;
 
 import java.util.List;
+import java.util.Optional;
 import org.prgrms.cream.domain.deal.domain.BuyingBid;
 import org.prgrms.cream.domain.deal.domain.Deal;
 import org.prgrms.cream.domain.deal.domain.SellingBid;
@@ -124,6 +125,41 @@ public class SellingService {
 				size
 			)
 			.orElseThrow(() -> new NotFoundBidException(ErrorCode.NOT_FOUND_RESOURCE));
+	}
+
+	@Transactional
+	public void cancelSellingBid(Long bidId, Long userId) {
+
+		SellingBid sellingBid = sellingRepository
+			.findByIdAndUserAndStatus(
+				bidId,
+				userService.findActiveUser(userId),
+				DealStatus.BIDDING.getStatus()
+			)
+			.orElseThrow(() -> new NotFoundBidException(ErrorCode.NOT_FOUND_RESOURCE));
+
+		sellingBid.changeStatus(DealStatus.BID_CANCELLED);
+
+		Optional<SellingBid> findSellingBid = sellingRepository
+			.findTopByProductAndSizeAndStatusOrderBySuggestPriceAscCreatedDateAsc(
+				sellingBid.getProduct(),
+				sellingBid.getSize(),
+				DealStatus.BIDDING.getStatus()
+			);
+
+		ProductOption productOption = productService
+			.findProductOptionByProductIdAndSize(
+				sellingBid
+					.getProduct()
+					.getId(),
+				sellingBid
+					.getSize()
+			);
+
+		productOption.updateSellBidPrice(findSellingBid.isEmpty() ? ZERO : findSellingBid
+			.get()
+			.getSuggestPrice()
+		);
 	}
 
 	public boolean existsSameBid(Long productId, String size, Long userId) {

--- a/src/main/java/org/prgrms/cream/domain/user/controller/UserShoppingInfoController.java
+++ b/src/main/java/org/prgrms/cream/domain/user/controller/UserShoppingInfoController.java
@@ -1,0 +1,29 @@
+package org.prgrms.cream.domain.user.controller;
+
+import org.prgrms.cream.domain.deal.service.SellingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users/{userId}")
+public class UserShoppingInfoController {
+
+	private final SellingService sellingService;
+
+	public UserShoppingInfoController(SellingService sellingService) {
+		this.sellingService = sellingService;
+	}
+
+	@DeleteMapping("/selling/{bidId}")
+	public ResponseEntity<Void> deleteSellingBid(
+		@PathVariable Long userId,
+		@PathVariable Long bidId
+	) {
+		sellingService.cancelSellingBid(bidId, userId);
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
+}


### PR DESCRIPTION
- 회원의 판매 입찰 취소에 대한 기능 추가
- soft-delete를 통해 판매 입찰 상태를 취소상태로만 변경
- productOption의 판매 최저가 변경
- 만약 입찰 취소후 남아있는 입찰이 없을 경우 판매 최저가 0으로 업데이트 
