### PR TITLE
구매 관련 API 리팩토링

### DIFF
--- a/src/main/java/org/prgrms/cream/domain/deal/domain/BuyingBid.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/domain/BuyingBid.java
@@ -85,7 +85,7 @@ public class BuyingBid extends BaseEntity {
 		return getCreatedDate().format(DateTimeFormatter.ofPattern("yy/MM/dd"));
 	}
 
-	public String getExpiryDate() {
+	public String getExpiredDate() {
 		return getCreatedDate()
 			.plusDays(deadline)
 			.format(DateTimeFormatter.ofPattern("yy/MM/dd"));
@@ -99,7 +99,7 @@ public class BuyingBid extends BaseEntity {
 			size,
 			suggestPrice,
 			status,
-			getExpiryDate()
+			getExpiredDate()
 		);
 	}
 

--- a/src/main/java/org/prgrms/cream/domain/deal/domain/BuyingBid.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/domain/BuyingBid.java
@@ -12,6 +12,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.prgrms.cream.domain.deal.dto.BidResponse;
 import org.prgrms.cream.domain.deal.dto.BuyingBidResponse;
 import org.prgrms.cream.domain.deal.model.DealStatus;
 import org.prgrms.cream.domain.product.domain.Product;
@@ -75,8 +76,19 @@ public class BuyingBid extends BaseEntity {
 		this.status = DealStatus.BID_CANCELLED.getStatus();
 	}
 
+	public void update(int price, int deadline) {
+		this.suggestPrice = price;
+		this.deadline = deadline;
+	}
+
 	public String getConvertCreatedDate() {
 		return getCreatedDate().format(DateTimeFormatter.ofPattern("yy/MM/dd"));
+	}
+
+	public String getExpiryDate() {
+		return getCreatedDate()
+			.plusDays(deadline)
+			.format(DateTimeFormatter.ofPattern("yy/MM/dd"));
 	}
 
 	public BuyingBidResponse toResponse() {
@@ -87,6 +99,14 @@ public class BuyingBid extends BaseEntity {
 			size,
 			suggestPrice,
 			status,
+			getExpiryDate()
+		);
+	}
+
+	public BidResponse toBidResponse() {
+		return new BidResponse(
+			suggestPrice,
+			deadline,
 			getConvertCreatedDate()
 		);
 	}

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/BidRequest.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/BidRequest.java
@@ -3,8 +3,8 @@ package org.prgrms.cream.domain.deal.dto;
 import javax.validation.constraints.Min;
 
 public record BidRequest(
-	@Min(30000) Integer price,
-	@Min(1) Integer deadline,
+	@Min(30000) int price,
+	@Min(1) int deadline,
 	Long userId
 ) {
 

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/BuyingBidResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/BuyingBidResponse.java
@@ -7,7 +7,7 @@ public record BuyingBidResponse(
 	String size,
 	int suggestPrice,
 	String status,
-	String createdDate
+	String expiryDate
 ) {
 
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/dto/BuyingHistoryResponse.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/dto/BuyingHistoryResponse.java
@@ -1,0 +1,9 @@
+package org.prgrms.cream.domain.deal.dto;
+
+import java.util.List;
+
+public record BuyingHistoryResponse(
+	List<BuyingBidResponse> buyingBidResponses
+) {
+
+}

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
@@ -51,7 +51,7 @@ public interface BuyingRepository extends JpaRepository<BuyingBid, Long> {
 
 	List<BuyingBid> findAllByUser(User user);
 
-	Optional<BuyingBid> findByProductAndSizeAndUser(Product pro, String size, User user);
+	Optional<BuyingBid> findByProductAndSizeAndUser(Product product, String size, User user);
 
 	boolean existsByProductAndSizeAndUser(Product product, String size, User user);
 }

--- a/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
+++ b/src/main/java/org/prgrms/cream/domain/deal/repository/BuyingRepository.java
@@ -50,4 +50,8 @@ public interface BuyingRepository extends JpaRepository<BuyingBid, Long> {
 	List<BuyingBid> findAllByUserAndStatus(User user, String status);
 
 	List<BuyingBid> findAllByUser(User user);
+
+	Optional<BuyingBid> findByProductAndSizeAndUser(Product pro, String size, User user);
+
+	boolean existsByProductAndSizeAndUser(Product product, String size, User user);
 }

--- a/src/main/java/org/prgrms/cream/domain/user/controller/UserShoppingInfoController.java
+++ b/src/main/java/org/prgrms/cream/domain/user/controller/UserShoppingInfoController.java
@@ -2,7 +2,7 @@ package org.prgrms.cream.domain.user.controller;
 
 import java.util.List;
 import java.util.Optional;
-import org.prgrms.cream.domain.deal.dto.BuyingBidResponse;
+import org.prgrms.cream.domain.deal.dto.BuyingHistoryResponse;
 import org.prgrms.cream.domain.deal.dto.DealHistoryResponse;
 import org.prgrms.cream.domain.deal.dto.SellingHistoryResponse;
 import org.prgrms.cream.domain.deal.service.BuyingService;
@@ -56,7 +56,7 @@ public class UserShoppingInfoController {
 	}
 
 	@GetMapping("/buying/bidding")
-	public ResponseEntity<ApiResponse<List<BuyingBidResponse>>> getBiddingHistory(
+	public ResponseEntity<ApiResponse<BuyingHistoryResponse>> getBiddingHistory(
 		@PathVariable Long userId,
 		@RequestParam Optional<String> status
 	) {


### PR DESCRIPTION
- 기존 구매 입찰 등록만을 위한 서비스 로직에서, 사용자가 같은 상품, 동일한 사이즈로 구매 입찰 등록 요청을 한다면 기존 구매 입찰 내역을 수정하는 로직으로 변경
- 구매 입찰 내역 조회의 응답 데이터 중 생성일자를 만료일자로 변경
- 구매 입찰 내역 응답 객체를 List -> 일급 컬렉션으로 변경